### PR TITLE
PR: "NoteList MultiDelete CheckBox UI NotWorking Init & recycler Issue Fix"

### DIFF
--- a/app/src/main/java/com/cleannote/model/NoteUiModel.kt
+++ b/app/src/main/java/com/cleannote/model/NoteUiModel.kt
@@ -14,5 +14,6 @@ data class NoteUiModel(val id: String,
 
 enum class NoteMode{
     Default,
-    SelectMode
+    MultiDefault,
+    MultiSelect
 }

--- a/app/src/main/java/com/cleannote/notelist/SubjectManager.kt
+++ b/app/src/main/java/com/cleannote/notelist/SubjectManager.kt
@@ -17,11 +17,8 @@ class SubjectManager @Inject constructor(){
     private val _deleteClickSubject: PublishSubject<NoteUiModel> = PublishSubject.create()
     val deleteClickSubject get() = _deleteClickSubject
 
-    private val _multiClickSubject: PublishSubject<Pair<Int, Boolean>> = PublishSubject.create()
-    val multiClickSubject get() = _multiClickSubject
-
     private val subjects: Set<Subject<*>> =
-        setOf(_clickNoteSubject, _longClickSubject,_deleteClickSubject, _multiClickSubject)
+        setOf(_clickNoteSubject, _longClickSubject,_deleteClickSubject)
 
     fun releaseSubjects(){
         subjects.forEach {

--- a/app/src/main/java/com/cleannote/notelist/holder/NoteViewHolder.kt
+++ b/app/src/main/java/com/cleannote/notelist/holder/NoteViewHolder.kt
@@ -5,11 +5,11 @@ import com.bumptech.glide.RequestManager
 import com.cleannote.app.databinding.ItemNoteListBinding
 import com.cleannote.model.NoteMode.*
 import com.cleannote.model.NoteUiModel
+import com.cleannote.notelist.NoteListAdapter
 import com.cleannote.notelist.SubjectManager
-import com.cleannote.notelist.swipe.SwipeHelperCallback
 import com.jakewharton.rxbinding4.view.clicks
 import com.jakewharton.rxbinding4.view.longClicks
-import com.jakewharton.rxbinding4.widget.checkedChanges
+import timber.log.Timber
 
 class NoteViewHolder(
     val binding: ItemNoteListBinding,
@@ -25,7 +25,8 @@ class NoteViewHolder(
             glideReqManager = requestManager
             noteUiModel = item
 
-            //initChecked()
+            if (item.mode == MultiDefault) checkboxDelete.isChecked = false
+            else if (item.mode == MultiSelect) checkboxDelete.isChecked = true
 
             swipeMenuDelete
                 .clicks()
@@ -38,9 +39,8 @@ class NoteViewHolder(
                 .clicks()
                 .map { item }
                 .doOnNext{
-                    if (checkboxDelete.isVisible) {
+                    if (it.mode != Default)
                         checkboxDelete.isChecked = !checkboxDelete.isChecked
-                    }
                 }
                 .subscribe(subjectManager.clickNoteSubject)
 
@@ -48,23 +48,9 @@ class NoteViewHolder(
                 .longClicks { true }
                 .subscribe(subjectManager.longClickSubject)
 
-            checkboxDelete
-                .checkedChanges()
-                .skipInitialValue()
-                .map { isChecked ->
-                    position to isChecked
-                }
-                .subscribe(subjectManager.multiClickSubject)
-
         }
     }
 
     private fun isClamped(holder: NoteViewHolder) = holder.itemView.tag as? Boolean ?: false
-
-    private fun initChecked() = with(binding){
-        if (checkboxDelete.isVisible) {
-            checkboxDelete.isChecked = false
-        }
-    }
 
 }

--- a/app/src/main/res/layout/item_note_list.xml
+++ b/app/src/main/res/layout/item_note_list.xml
@@ -64,10 +64,9 @@
         android:buttonTint="@color/colorAccent"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:visible="@{noteUiModel.mode == NoteMode.SelectMode}"/>
-        <!--app:visible="@{noteUiModel.mode == NoteMode.MultiDefault || noteUiModel.mode == NoteMode.MultiSelected}"-->
-        <!--android:checked="@{ noteUiModel.mode == NoteMode.MultiSelected ? true : false }"-->
-
+        app:visible="@{noteUiModel.mode == NoteMode.MultiDefault || noteUiModel.mode == NoteMode.MultiSelect}"
+        />
+    <!--android:checked="@{ noteUiModel.mode == NoteMode.MultiSelect ? true : false}"-->
 
     <TextView
         android:id="@+id/edit_title"

--- a/buildSrc/build/source-roots/buildSrc/source-roots.txt
+++ b/buildSrc/build/source-roots/buildSrc/source-roots.txt
@@ -1,0 +1,8 @@
+src/main/resources
+src/main/java
+src/main/groovy
+src/main/kotlin
+src/test/resources
+src/test/java
+src/test/groovy
+src/test/kotlin

--- a/presentation/src/main/java/com/cleannote/presentation/notelist/NoteListViewModel.kt
+++ b/presentation/src/main/java/com/cleannote/presentation/notelist/NoteListViewModel.kt
@@ -1,7 +1,6 @@
 package com.cleannote.presentation.notelist
 
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.lifecycle.*
 import com.cleannote.domain.Constants.FILTER_ORDERING_KEY
 import com.cleannote.domain.Constants.ORDER_DESC
@@ -232,7 +231,6 @@ constructor(
     }
 
     private fun List<NoteView>.takeTargetToLast(target: NoteView): List<NoteView>{
-        Log.d("RxCleanNote","removeTargetIndex: ${indexOf(target)}")
         val fromLastToDeleteIndex = (lastIndex - indexOf(target)).plus(1)
         return this.takeLast(fromLastToDeleteIndex)
     }
@@ -247,7 +245,6 @@ constructor(
     ){
         setQuery(getQuery()
             .apply {
-                Log.d("RxCleanNote", "deletePage: ${deletedPage}, startIndex: $index")
                 page =  deletedPage
                 startIndex = index
             }


### PR DESCRIPTION
## issue #21 Solve

- NoteUIModel -> Mode(Default, MultiDefault, MultiSelect)
- NoteListAdapter
   - HashSet -> HashMap
     > b/c NoteList NoteUIModel -> NoteListAdatper NoteUIModel Mode Change -> Then HashCode Different result
        HashSet Remove Not Working -> so use HashMap
   - Add Func fetchRecyclerView()
     > VM totalNotes is NoteView (not contain mode) -> NoteListFragment LoadedNotes is NoteMode init 
     -> NextPage load and scroll top checked Init issue 
     -> so HashMap(checkedNotes) isNotEmpty -> loadedNotes set mode = MultiSelect  
- NoteHolder
  - Delete CheckBox.RxBinding (checkedChanges)
  - Checkbox UI Process Only bind
  - Checked Data Process Only NoteListAdapter ( with HashMap )